### PR TITLE
Fix directory creation permissions.

### DIFF
--- a/application/lambda/lambda_fs.go
+++ b/application/lambda/lambda_fs.go
@@ -80,7 +80,7 @@ func (local *localLambda) EnsureDir(path string) error {
 	if !isLocal {
 		return fmt.Errorf("non-local file")
 	}
-	err := os.MkdirAll(path, 0600)
+	err := os.MkdirAll(path, 0700)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Directories needs to have their executable bits set, so that files under them could be accessed.