### PR TITLE
Fix paths of static files.

### DIFF
--- a/application/lambda/lambda.go
+++ b/application/lambda/lambda.go
@@ -67,7 +67,8 @@ func (local *localLambda) Invoke(ctx context.Context, request types.Request, res
 	defer request.Body.Close()
 
 	if local.staticDir != "" && request.Method == http.MethodGet {
-		return local.writeStaticFile(request.Path, response)
+		path := strings.SplitN(request.Path, "/", 2)[1]
+		return local.writeStaticFile(path, response)
 	}
 
 	if len(local.manifest.Run) == 0 {


### PR DESCRIPTION
Without the patch, the program does not seem to serve static files correctly.