### PR TITLE
Remove all references to bintray.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,4 +45,3 @@ jobs:
         args: release --rm-dist --release-footer _footer.md --release-header release-note.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        UPLOAD_BINTRAY_SECRET: ${{ secrets.UPLOAD_BINTRAY_SECRET }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -103,15 +103,6 @@ nfpms:
       - deb
     builds:
       - client
-uploads:
-  - name: bintray
-    method: PUT
-    mode: archive
-    username: reddec
-    custom_artifact_name: true
-    ids:
-      - debian
-    target: 'https://api.bintray.com/content/reddec/debian/{{ .ProjectName }}/{{ .Version }}/{{ .ArtifactName }};publish=1;deb_component=main;deb_distribution=all;deb_architecture={{ .Arch }}'
 archives:
 - replacements:
     Linux: linux

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 [![license](https://img.shields.io/github/license/reddec/trusted-cgi.svg)](https://github.com/reddec/trusted-cgi)
 [![](https://godoc.org/github.com/reddec/trusted-cgi?status.svg)](http://godoc.org/github.com/reddec/trusted-cgi/application)
 [![donate](https://img.shields.io/badge/help_by️-donate❤-ff69b4)](http://reddec.net/about/#donate)
-[![Download](https://api.bintray.com/packages/reddec/debian/trusted-cgi/images/download.svg)](https://bintray.com/reddec/debian/trusted-cgi/_latestVersion)
-
-![](https://bintray-binary-objects-or-production.s3-accelerate.amazonaws.com/80ee75735ebc642670140a263e7e94f32fb8ce932933626ef3c4812006295af0)
 
 Lightweight self-hosted lambda/applications/cgi/serverless-functions engine. 
 
@@ -35,7 +32,7 @@ Since `0.3.3` Linux, Darwin and even Windows OS supported: pre-built binaries co
 
 TL;DR;
 
-* for production for debian servers - use bintray repository (recommend)
+* for production for debian servers - use ~~bintray repository~~ github release (recommend)
 * locally or non-debian server - [download binary](https://github.com/reddec/trusted-cgi/releases) and run
 * for quick tests or for limited production - use docker image (`docker run --rm -p 3434:3434 reddec/trusted-cgi`)
 

--- a/_footer.md
+++ b/_footer.md
@@ -1,27 +1,6 @@
 For Ubuntu/Debian (should be for all LTS)
 
 ```bash
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
-echo "deb https://dl.bintray.com/reddec/debian all main" | sudo tee /etc/apt/sources.list.d/trusted-cgi.list
-sudo apt update
-sudo apt install trusted-cgi
-```
-
-Optionally you may install a server and a client separately.
-
-
-**Server only**
-
-Daemon only.
-
-```bash
-sudo apt install trusted-cgi-server
-```
-
-**Client only**
-
-CLI tools only.
-
-```bash
-sudo apt install trusted-cgi-client
+sudo wget -O trusted-cgi_0.3.6_linux_amd64.deb https://github.com/reddec/trusted-cgi/releases/download/v0.3.6/trusted-cgi_0.3.6_linux_amd64.deb
+sudo apt install ./trusted-cgi_0.3.6_linux_amd64.deb
 ```

--- a/docs/administrating/installation.md
+++ b/docs/administrating/installation.md
@@ -9,25 +9,23 @@ nav_order: 1
 
 TL;DR;
 
-* for production for debian servers - use bintray repository (recommend)
+* for production for debian servers - use ~~bintray repository~~ github release (recommend)
 * locally or non-debian server - download binary and run
 * for quick tests or for limited production - use docker image
 
 ## Debian/Ubuntu
 
-Add the repository (needed only once)
+Download the latest release.
 
 ```bash
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
-echo "deb https://dl.bintray.com/reddec/debian all main" | sudo tee /etc/apt/sources.list.d/trusted-cgi.list
-sudo apt update
+sudo wget -O trusted-cgi_0.3.6_linux_amd64.deb https://github.com/reddec/trusted-cgi/releases/download/v0.3.6/trusted-cgi_0.3.6_linux_amd64.deb
 ```
 
 Install your distribution:
 
-* standard (basic templates supported): `sudo apt install trusted-cgi`
-*  minimal (actions will not work): `sudo apt install --no-install-recommends trusted-cgi`
-* maximum (all pre-made templates available): `sudo apt install trusted-cgi php-cli nodejs npm`
+* standard (basic templates supported): `sudo apt install ./trusted-cgi_0.3.6_linux_amd64.deb`
+*  minimal (actions will not work): `sudo apt install --no-install-recommends ./trusted-cgi_0.3.6_linux_amd64.deb`
+* maximum (all pre-made templates available): `sudo apt install ./trusted-cgi_0.3.6_linux_amd64.deb php-cli nodejs npm`
 
 Of course, you may install required packages later.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,6 @@
 [![license](https://img.shields.io/github/license/reddec/trusted-cgi.svg)](https://github.com/reddec/trusted-cgi)
 [![](https://godoc.org/github.com/reddec/trusted-cgi?status.svg)](http://godoc.org/github.com/reddec/trusted-cgi/application)
 [![donate](https://img.shields.io/badge/help_by️-donate❤-ff69b4)](http://reddec.net/about/#donate)
-[![Download](https://api.bintray.com/packages/reddec/debian/trusted-cgi/images/download.svg)](https://bintray.com/reddec/debian/trusted-cgi/_latestVersion)
 
 Lightweight self-hosted lambda/applications/cgi/serverless-functions engine. 
 
@@ -102,7 +101,7 @@ So, 'cause I am a developer I decided to make my own wheels ;-)
 
 TL;DR;
 
-* for production for debian servers - use bintray repository (recommend)
+* for production for debian servers - use ~~bintray repository~~ github release (recommend)
 * locally or non-debian server - [download binary](https://github.com/reddec/trusted-cgi/releases) and run
 * for quick tests or for limited production - use docker image (`docker run --rm -p 3434:3434 reddec/trusted-cgi`)
 


### PR DESCRIPTION
I removed references to the Bintray Debian repository and added instructions to install via the GitHub release .deb file. I would love to restore a true Debian repo, especially since the `footer.md` file has moot instructions to download different and now unavailable packages. Any ideas on this?