### PR TITLE
fix: jwt used before issued. (#15)

### DIFF
--- a/api/services/user_srv.go
+++ b/api/services/user_srv.go
@@ -74,7 +74,7 @@ func (srv *userSrv) Login(ctx context.Context, login, password string) (*api.Tok
 	}
 
 	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"iat":  time.Now().Add(srv.config.LifeTime),
+		"exp":  time.Now().Add(srv.config.LifeTime).Unix(),
 		"user": login,
 	})
 	v, err := tok.SignedString([]byte(srv.secret))


### PR DESCRIPTION
It seems that iat should be replaced with `exp` in the `jwt` issued at login.

fix 👇

![image](https://user-images.githubusercontent.com/30215105/199231792-56a07ff7-1a18-414c-a224-76e703aae253.png)
