### PR TITLE
Fix path on debian systemd service

### DIFF
--- a/debian/trusted-cgi.service
+++ b/debian/trusted-cgi.service
@@ -2,7 +2,7 @@
 Description=Lightweight self-hosted serverless-functions engine
 
 [Service]
-ExecStart=/usr/local/bin/trusted-cgi
+ExecStart=/usr/bin/trusted-cgi
 EnvironmentFile=/etc/trusted-cgi/trusted-cgi.env
 Restart=always
 RestartSec=3


### PR DESCRIPTION
Hello,

The path in the debian package is /usr/bin/trusted-cgi, however the systemd file point to /usr/local/bin/trusted-cgi.

![image](https://github.com/reddec/trusted-cgi/assets/4920043/d1cdb988-e600-41b6-b5dd-642cf23302dc)


This fix the path in the systemd service :)

Bests,