### PR TITLE
Fix cgi-ctl's clone title in the documentation

### DIFF
--- a/docs/cgi-ctl/clone.md
+++ b/docs/cgi-ctl/clone.md
@@ -4,7 +4,7 @@ title: clone
 parent: Control util
 nav_order: 203
 ---
-# upload
+# clone
 
 From `0.3.2`
 


### PR DESCRIPTION
Documentation for `cgi-ctl clone` was titled as _upload_ instead of _clone_.